### PR TITLE
Update jsdonk

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jsdoc-babel": "^0.2.1",
     "jsdoc-react-proptypes": "^1.0.0",
     "jsdom": "^9.8.3",
-    "jsdonk": "0.4.10",
+    "jsdonk": "^0.4.13",
     "node-sass": "^3.11.2",
     "nyc": "^10.0.0",
     "react": "^15.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,7 +1037,7 @@ babel-traverse@^6.22.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.21.0:
+babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.21.0, babel-types@^6.7.2, babel-types@^6.8.0, babel-types@^6.9.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.21.0.tgz#314b92168891ef6d3806b7f7a917fdf87c11a4b2"
   dependencies:
@@ -1046,7 +1046,7 @@ babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.21
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.7.2, babel-types@^6.8.0, babel-types@^6.9.0:
+babel-types@^6.19.0, babel-types@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.22.0.tgz#2a447e8d0ea25d2512409e4175479fd78cc8b1db"
   dependencies:
@@ -1055,13 +1055,13 @@ babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.7.2, babel-types@^6.8.0
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.1.0, babylon@^6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
-
-babylon@^6.11.0, babylon@^6.13.0:
+babylon@^6.1.0, babylon@^6.11.0, babylon@^6.13.0:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
+
+babylon@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -3097,9 +3097,9 @@ jsdom@^9.8.3:
     whatwg-url "^4.1.0"
     xml-name-validator ">= 2.0.1 < 3.0.0"
 
-jsdonk@0.4.10:
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/jsdonk/-/jsdonk-0.4.10.tgz#3fedf9f596d43cded83b541986e0d9dcce0d5bbd"
+jsdonk@^0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/jsdonk/-/jsdonk-0.4.13.tgz#b2c86191836347d206e565d688a7531b9fc351ed"
   dependencies:
     immutable "^3.8.1"
     prismjs "^1.5.1"


### PR DESCRIPTION
- Fixes unreadable code blocks in doclet descriptions that had the same background colour as text colour
- Constructors now render correctly