### PR TITLE
Don't render non-number points in <Scatter>

### DIFF
--- a/src/component/canvas/ScatterRenderable.jsx
+++ b/src/component/canvas/ScatterRenderable.jsx
@@ -128,7 +128,7 @@ export class ScatterRenderable extends React.PureComponent {
     render(): React.Element<any> {
         return <g>
             {this.props.scaledData
-                .filter(data => isNumber(data.x) && isNumber(data.y))
+                .filter(row => isNumber(row.x) && isNumber(row.y))
                 .map(this.buildDot)}
         </g>;
     }

--- a/src/component/canvas/ScatterRenderable.jsx
+++ b/src/component/canvas/ScatterRenderable.jsx
@@ -39,7 +39,7 @@ const defaultDot = (props: Object): React.Element<any> => {
     return <circle fill='black' r={3} {...props.dotProps}/>;
 };
 
-
+const isNumber = (value) => typeof value === 'number' && !isNaN(value);
 
 /**
  *
@@ -110,8 +110,6 @@ export class ScatterRenderable extends React.PureComponent {
         row: Object,
         index: number
     ): ?React.Element<any> {
-        if(typeof row.x !== 'number' || typeof row.y !== 'number') return null;
-
         const {dot: Dot, dotProps} = this.props;
         return <Dot
             key={index}
@@ -129,7 +127,9 @@ export class ScatterRenderable extends React.PureComponent {
 
     render(): React.Element<any> {
         return <g>
-            {this.props.scaledData.map(this.buildDot)}
+            {this.props.scaledData
+                .filter(data => isNumber(data.x) && isNumber(data.y))
+                .map(this.buildDot)}
         </g>;
     }
 }

--- a/src/component/canvas/__test__/ScatterRenderable-test.js
+++ b/src/component/canvas/__test__/ScatterRenderable-test.js
@@ -249,7 +249,7 @@ test('ScatterRenderable won\'t render a dot for null points', tt => {
 
 test('ScatterRenderable won\'t render a dot for NaN points', tt => {
     const scaledWithNaN = [...scaledData, {
-        x: "2017-01-01",
+        x: 100,
         y: NaN,
         radius: 30
     }];


### PR DESCRIPTION
I had to make another PR because I realised that the change to `typeof n === 'number'` actually returns true for NaN but the unit test was still passing because I was passing a String through for `row.x` causing the logic to short circuit before it actually tested the type of `row.y` (which was NaN)