### PR TITLE
add: handling for null values in column chart

### DIFF
--- a/src/component/__test__/Chart-test.js
+++ b/src/component/__test__/Chart-test.js
@@ -114,8 +114,6 @@ test('if xColumn is an array then child components will receive x0, x1 in scaled
     const chart = shallow(<Chart width={200} height={200} data={data} xColumn={["supply", "demand"]} >
         <Line yColumn="month" />
     </Chart>);
-    console.log();
-
 
     tt.is(typeof chart.childAt(0).childAt(0).props().scaledData[0].x0, 'number');
     tt.is(typeof chart.childAt(0).childAt(0).props().scaledData[1].x1, 'number');
@@ -134,5 +132,3 @@ test('component will update dimensions and scaled data on componentWillReceivePr
     chart.componentWillReceiveProps(chart.props);
     tt.not(old, chart.dimensions);
 });
-
-

--- a/src/component/canvas/ColumnRenderable.jsx
+++ b/src/component/canvas/ColumnRenderable.jsx
@@ -148,7 +148,7 @@ export class ColumnRenderable extends React.PureComponent {
         index: number,
         orientation: 'vertical'|'horizontal',
         bandwidth: number
-    ): React.Element<any> {
+    ): ?React.Element<any> {
         const {column: Column} = this.props;
 
         let x, y, width, height;
@@ -164,6 +164,10 @@ export class ColumnRenderable extends React.PureComponent {
             width = row.x;
             height = bandwidth;
         }
+
+        // Don't render a column for null values, svg will treat null as a 0
+        // and render a full height column
+        if(x == undefined || y == undefined) return null;
 
         return <Column
             key={
@@ -195,7 +199,7 @@ export class ColumnRenderable extends React.PureComponent {
         const bandwidth = orientation === 'vertical' ? xScale.bandwidth() : yScale.bandwidth();
 
         return <g>
-            {this.props.scaledData.map((row: Object, index: number): React.Element<any> => {
+            {this.props.scaledData.map((row: Object, index: number): ?React.Element<any> => {
                 return this.buildColumn(row, index, orientation, bandwidth);
             })}
         </g>;
@@ -245,4 +249,3 @@ export default class Column extends React.Component {
         return <ColumnRenderable {...this.props} />;
     }
 }
-

--- a/src/component/canvas/ColumnRenderable.jsx
+++ b/src/component/canvas/ColumnRenderable.jsx
@@ -50,6 +50,7 @@ function DefaultColumn(props: Object): React.Element<any> {
     />;
 }
 
+const isNumber = (value) => typeof value === 'number' && !isNaN(value);
 
 /**
  *
@@ -149,6 +150,7 @@ export class ColumnRenderable extends React.PureComponent {
         orientation: 'vertical'|'horizontal',
         bandwidth: number
     ): ?React.Element<any> {
+        if(!isNumber(row.x) || !isNumber(row.y)) return null;
         const {column: Column} = this.props;
 
         let x, y, width, height;
@@ -164,10 +166,6 @@ export class ColumnRenderable extends React.PureComponent {
             width = row.x;
             height = bandwidth;
         }
-
-        // Don't render a column for null values, svg will treat null as a 0
-        // and render a full height column
-        if(x == undefined || y == undefined) return null;
 
         return <Column
             key={

--- a/src/component/canvas/LabelRenderable.jsx
+++ b/src/component/canvas/LabelRenderable.jsx
@@ -47,11 +47,11 @@ export class LabelRenderable extends React.PureComponent {
         row: Object,
         index: number
     ): ?React.Element<any> {
+        if(!isNumber(row.x) || !isNumber(row.y)) return null;
         const {label: Label, labelProps} = this.props;
         const rawRow = this.props.data.rows.get(index);
         const labelText = this.props.labelTextFromRow(rawRow);
-        // Don't render a label for null values
-        if(row.x == undefined || row.y == undefined) return null;
+
         return labelText && <Label
             key={index}
             x={row.x + this.props.labelOffset[0]}
@@ -71,9 +71,7 @@ export class LabelRenderable extends React.PureComponent {
 
     render(): React.Element<any> {
         return <g>
-            {this.props.scaledData
-                .filter(row => isNumber(row.x) && isNumber(row.y))
-                .map(this.buildLabel)}
+            {this.props.scaledData.map(this.buildLabel)}
         </g>;
     }
 }

--- a/src/component/canvas/LabelRenderable.jsx
+++ b/src/component/canvas/LabelRenderable.jsx
@@ -50,6 +50,8 @@ export class LabelRenderable extends React.PureComponent {
         const {label: Label, labelProps} = this.props;
         const rawRow = this.props.data.rows.get(index);
         const labelText = this.props.labelTextFromRow(rawRow);
+        // Don't render a label for null values
+        if(row.x == undefined || row.y == undefined) return null;
         return labelText && <Label
             key={index}
             x={row.x + this.props.labelOffset[0]}

--- a/src/component/canvas/ScatterRenderable.jsx
+++ b/src/component/canvas/ScatterRenderable.jsx
@@ -112,6 +112,7 @@ export class ScatterRenderable extends React.PureComponent {
         row: Object,
         index: number
     ): ?React.Element<any> {
+        if(!isNumber(row.x) || !isNumber(row.y)) return null;
         const {dot: Dot, dotProps} = this.props;
         return <Dot
             key={index}
@@ -129,9 +130,7 @@ export class ScatterRenderable extends React.PureComponent {
 
     render(): React.Element<any> {
         return <g>
-            {this.props.scaledData
-                .filter(row => isNumber(row.x) && isNumber(row.y))
-                .map(this.buildDot)}
+            {this.props.scaledData.map(this.buildDot)}
         </g>;
     }
 }

--- a/src/component/canvas/__test__/ColumnRenderable-test.js
+++ b/src/component/canvas/__test__/ColumnRenderable-test.js
@@ -59,6 +59,11 @@ const rows = [
         demand: 2560,
         property_type: "Other",
         supply: 5
+    },
+    {
+        demand: null,
+        property_type: "Unknown",
+        supply: null
     }
 ];
 
@@ -158,4 +163,8 @@ test('Column can render bar charts also', tt => {
     // be greater than 0 for all but the first column
     tt.is(secondColumnProps.x, 0);
     tt.true(secondColumnProps.y > 0);
+});
+
+test('Column wont render columns with null values', tt => {
+    tt.is(ColumnElement.at(0).shallow().children().length, 7);
 });

--- a/src/component/canvas/__test__/LabelRenderable-test.js
+++ b/src/component/canvas/__test__/LabelRenderable-test.js
@@ -270,7 +270,6 @@ test('LabelRenderable allows custom circle rendering', tt => {
 });
 
 test('LabelRenderable custom label has x and y params', tt => {
-    console.log(CustomLabel.childAt(0).shallow());
     tt.is(CustomLabel.childAt(0).shallow().prop('x'), xScale(rows[0].month));
     tt.is(CustomLabel.childAt(0).shallow().prop('y'), 200 - yScale(rows[0].supply));
 });


### PR DESCRIPTION
if you pass null in as a x or y value for a svg rect then it will
handle it as a zero, and in the case of a y coordinate will render
a full height bar. It's pretty unlikely that users would want this
so this commit updates the default behaviour to not render null vals